### PR TITLE
Add expected-space notice and user confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Each argument is optional. You must supply at least one value for each argument 
 
 Flag | Description
 ---- | :----
+-c | Count of files. Using `_` and `,` is permitted.
 -p | Filename prefix.
 -e | Extension of the generated files. The opening period is optional. If not specified, no extension is added.
--s | Desired size of each file in bytes. If specified, files will be populated with random alphanumeric characters; otherwise, each file will only contain its own name.
+-s | Desired size of each file in bytes. If specified, files will be populated with random alphanumeric characters; otherwise, each file will only contain its own name. Using `_` and `,` is permitted.
 -o | The output subdirectory, which will be created, if needed. Otherwise, a default is used.
 -d | Delay in milliseconds to be applied between each file's creation. Defaults to 0 if unspecified.
 -h | See the instructions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unique File Generator (Rust Version)
+# Unique File Generator (Rust Version) 🦀
 
 I've largely rewritten my [C# unique file generator](https://github.com/codeconscious/unique-file-generator) in Rust as a way to get more familiar with the language. Most of the features have been merged, and it's now functional!
 
@@ -8,11 +8,11 @@ This command line tool allows you to quickly and easily create an arbitrary numb
 
 At the minimum, you must specify the number of files you want to generate using `-c` or `--count`. This should be a single positive integer.
 
-*Important note:* Unlike the C# version, this tool does not yet check for available space on your computer or for heavy workloads. Thus, be sure you don't accidentally fill your drive.
+*Important note:* Unlike the C# version, this tool does not yet check for available space on your computer or for heavy workloads, so be sure you don't accidentally fill your drive. That said, it will show the expected space required and give you a chance to cancel.
 
-### Argument Options
+### Arguments
 
-Each argument flag is optional. You must supply at least one value for each argument used. If you supply multiple values for an argument, they will be concatenated into one string divided by spaces.
+Each argument is optional. You must supply at least one value for each argument used.
 
 Flag | Description
 ---- | :----

--- a/src/arg_parsing.rs
+++ b/src/arg_parsing.rs
@@ -163,6 +163,13 @@ impl Arguments {
         })
     }
 
+    pub fn expected_operation_size(&self, default_file_size_bytes: usize) -> usize {
+        match self.size {
+            Some(s) => self.count * s,
+            None => self.count * default_file_size_bytes,
+        }
+    }
+
     /// Prepends a specified prefix, if any, and appends a specified
     /// extension, if any, converting a base filename into a full one.
     pub fn full_filename(&self, base: &str) -> String {

--- a/src/arg_parsing.rs
+++ b/src/arg_parsing.rs
@@ -115,7 +115,7 @@ impl Arguments {
         subdirectory: String,
         delay: Option<String>,
     ) -> Result<Self, String> {
-        let parsed_count = match count.parse::<usize>() {
+        let parsed_count = match count.replace("_", "").parse::<usize>() {
             Ok(n) => {
                 if n == 0 {
                     return Err("The file count must be greater than 0.".to_string());
@@ -133,7 +133,7 @@ impl Arguments {
 
         let parsed_size = match size {
             None => None,
-            Some(s) => match s.parse::<usize>() {
+            Some(s) => match s.replace("_", "").parse::<usize>() {
                 Ok(n) => {
                     if n == 0 {
                         return Err("The size must be greater than 0.".to_string());
@@ -163,10 +163,20 @@ impl Arguments {
         })
     }
 
-    pub fn expected_operation_size(&self, default_file_size_bytes: usize) -> usize {
-        match self.size {
+    pub fn expected_operation_size(&self, default_file_size_bytes: usize) -> String {
+        let size = match self.size {
             Some(s) => self.count * s,
             None => self.count * default_file_size_bytes,
+        };
+
+        if size < 1_000 {
+            size.to_formatted_string(&Locale::en) + " B"
+        } else if size < 10_000_000 {
+            (size / 1000).to_formatted_string(&Locale::en) + " KB"
+        } else if size < 1_000_000_000 {
+            (size / 1_000_000).to_formatted_string(&Locale::en) + " MB"
+        } else {
+            (size / 1_000_000_000).to_formatted_string(&Locale::en) + " GB"
         }
     }
 

--- a/src/arg_parsing.rs
+++ b/src/arg_parsing.rs
@@ -115,7 +115,7 @@ impl Arguments {
         subdirectory: String,
         delay: Option<String>,
     ) -> Result<Self, String> {
-        let parsed_count = match count.replace("_", "").parse::<usize>() {
+        let parsed_count = match count.replace("_", "").replace(",", "").parse::<usize>() {
             Ok(n) => {
                 if n == 0 {
                     return Err("The file count must be greater than 0.".to_string());
@@ -133,7 +133,7 @@ impl Arguments {
 
         let parsed_size = match size {
             None => None,
-            Some(s) => match s.replace("_", "").parse::<usize>() {
+            Some(s) => match s.replace("_", "").replace(",", "").parse::<usize>() {
                 Ok(n) => {
                     if n == 0 {
                         return Err("The size must be greater than 0.".to_string());
@@ -169,14 +169,16 @@ impl Arguments {
             None => self.count * default_file_size_bytes,
         };
 
+        let locale = &Locale::en;
+
         if size < 1_000 {
-            size.to_formatted_string(&Locale::en) + " B"
+            size.to_formatted_string(locale) + " B"
         } else if size < 10_000_000 {
-            (size / 1000).to_formatted_string(&Locale::en) + " KB"
+            (size / 1000).to_formatted_string(locale) + " KB"
         } else if size < 1_000_000_000 {
-            (size / 1_000_000).to_formatted_string(&Locale::en) + " MB"
+            (size / 1_000_000).to_formatted_string(locale) + " MB"
         } else {
-            (size / 1_000_000_000).to_formatted_string(&Locale::en) + " GB"
+            (size / 1_000_000_000).to_formatted_string(locale) + " GB"
         }
     }
 

--- a/src/generate_files.rs
+++ b/src/generate_files.rs
@@ -4,16 +4,12 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-use num_format::Locale;
-use num_format::ToFormattedString;
-
 use crate::arg_parsing::Arguments;
 
 pub fn verify_continue(args: &Arguments) -> bool {
     println!(
-        "This operation will take approximately {} bytes of space on your drive.",
+        "This operation will take approximately {} of space on your drive.",
         args.expected_operation_size(20)
-            .to_formatted_string(&Locale::en)
     );
 
     loop {
@@ -26,7 +22,9 @@ pub fn verify_continue(args: &Arguments) -> bool {
 
         match response.trim().to_lowercase().as_str() {
             "y" => return true,
+            "yes" => return true,
             "n" => return false,
+            "no" => return false,
             _ => {
                 continue;
             }

--- a/src/generate_files.rs
+++ b/src/generate_files.rs
@@ -1,7 +1,38 @@
 use std::fs;
 use std::fs::File;
-use std::io::prelude::*;
+use std::io;
+use std::io::Write;
 use std::path::Path;
+
+use num_format::Locale;
+use num_format::ToFormattedString;
+
+use crate::arg_parsing::Arguments;
+
+pub fn verify_continue(args: &Arguments) -> bool {
+    println!(
+        "This operation will take approximately {} bytes of space on your drive.",
+        args.expected_operation_size(20)
+            .to_formatted_string(&Locale::en)
+    );
+
+    loop {
+        let mut response = String::new(); // Must be within this loop.
+        print!("Continue? (Y/n)  ");
+        io::stdout().flush().unwrap(); // The previous one will not display immediately with this.
+        std::io::stdin()
+            .read_line(&mut response)
+            .expect("Failed to read from stdin!");
+
+        match response.trim().to_lowercase().as_str() {
+            "y" => return true,
+            "n" => return false,
+            _ => {
+                continue;
+            }
+        }
+    }
+}
 
 pub fn create_file(filename: String, content: String, subfolder: String) -> std::io::Result<()> {
     prepare_subdirectory(&subfolder)?;
@@ -14,6 +45,7 @@ pub fn create_file(filename: String, content: String, subfolder: String) -> std:
         )
         .as_str(),
     );
+
     file.write_all(content.as_bytes()).expect(
         format!(
             "Error while writing content to file \"{}\"!",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod random_strings;
 
 use arg_parsing::{parse_args, Arguments};
 use colored::*;
+use generate_files::verify_continue;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use random_strings::random_alphanumeric_string;
 use std::thread;
@@ -21,8 +22,13 @@ fn main() {
     };
 
     let safe_args = args.unwrap();
-    let progress_bar = prepare_progress_bar(&safe_args);
 
+    if verify_continue(&safe_args) == false {
+        println!("Operation cancelled!");
+        return;
+    }
+
+    let progress_bar = prepare_progress_bar(&safe_args);
     for i in 0..safe_args.count {
         let new = min(i, safe_args.count) as u64;
         progress_bar.set_position(new);


### PR DESCRIPTION
- [X] Show the user approximately how much space is necessary.
- [X] Ask user to confirm the operation
- [X] Support `_` and `,` in argument numbers
- [ ] ~~Add an option to skip the confirmation (expect perhaps if there would not be enough space left on the disk)~~ (Will do in another PR)