### PR TITLE
Remove unsafe `.unwrap()` call

### DIFF
--- a/src/arg_parsing.rs
+++ b/src/arg_parsing.rs
@@ -186,7 +186,13 @@ impl Arguments {
         };
 
         match &self.extension {
-            Some(ext) => prefix + base + "." + ext.strip_prefix('.').unwrap(),
+            Some(ext) => {
+                let safe_ext = match ext.strip_prefix('.') {
+                    Some(ext_no_period) => ext_no_period,
+                    None => ext,
+                };
+                prefix + base + "." + safe_ext
+            }
             None => prefix + base,
         }
     }


### PR DESCRIPTION
This fixes issue #10. I found that `.strip_prefix()` returns a `Result` that should be handled properly. A `None` would crash the program.